### PR TITLE
fix dropdown menu

### DIFF
--- a/components/StyledForm.js
+++ b/components/StyledForm.js
@@ -75,6 +75,7 @@ export const Language = styled.button`
 
 export const DropdownContent = styled.div`
   opacity: 0;
+  z-index: -1;
   position: absolute;
   width: 77px;
   overflow: auto;


### PR DESCRIPTION
there was a bug in the new dropdown menu: since I had to change `display: none` to `opacity: 0` in order to avoid the error message that the form fields cannot be validated, the invisible but present dropdown menu overshadowed the form and other elements. I fixed it by adding `z-index: -1` to the invisible dropdown. 